### PR TITLE
Remove duplicate assistant script and centralize logging

### DIFF
--- a/assistant.py
+++ b/assistant.py
@@ -9,8 +9,9 @@ from datetime import datetime
 from pathlib import Path
 from typing import List
 
-# //: each session logs to its own file
-LOG_DIR = Path(__file__).resolve().parent / "log"
+# //: each session logs to its own file in the repository root
+ROOT_DIR = Path(__file__).resolve().parent
+LOG_DIR = ROOT_DIR / "log"
 SESSION_ID = datetime.utcnow().strftime("%Y%m%d-%H%M%S")
 LOG_PATH = LOG_DIR / f"{SESSION_ID}.log"
 

--- a/cmd/assistant.py
+++ b/cmd/assistant.py
@@ -1,1 +1,0 @@
-../assistant.py

--- a/cmd/monitor.sh
+++ b/cmd/monitor.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
-LOG_DIR="$(cd "$(dirname "$0")/../log" && pwd)"
+# Tail assistant logs from the repository root's log directory
 
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+LOG_DIR="$ROOT_DIR/log"
+
+mkdir -p "$LOG_DIR"
 tail -f "$LOG_DIR"/*.log


### PR DESCRIPTION
## Summary
- drop the `cmd/assistant.py` symlink so the root script is the single source
- ensure assistant sessions log under the repository’s `log/`
- harden `monitor.sh` to tail logs from the root `log/` directory

## Testing
- `python -m py_compile assistant.py`
- `bash -n cmd/monitor.sh`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893288731408329a0a21ea789cd21d1