### PR TITLE
monitor: wait for log files before tailing

### DIFF
--- a/cmd/monitor.sh
+++ b/cmd/monitor.sh
@@ -7,4 +7,13 @@ ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 LOG_DIR="$ROOT_DIR/log"
 
 mkdir -p "$LOG_DIR"
+# Wait for at least one log file to exist before tailing
+shopt -s nullglob
+log_files=("$LOG_DIR"/*.log)
+while [ ${#log_files[@]} -eq 0 ]; do
+  echo "Waiting for logs in $LOG_DIR..."
+  sleep 1
+  log_files=("$LOG_DIR"/*.log)
+done
+shopt -u nullglob
 tail -f "$LOG_DIR"/*.log


### PR DESCRIPTION
## Summary
- wait for log files before tailing
- print friendly message while waiting

## Testing
- `bash -n cmd/monitor.sh`
- `shellcheck cmd/monitor.sh`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68932bd7f6f48329a5abb0625b2b992c