### PR TITLE
Use fixed log directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Other interfaces—serial TTYs, named pipes or custom RPC schemes—remain feasi
 
 ## assistant.py
 
-The assistant is invoked after login and serves as the primary shell for Arianna Core. Each session creates a fresh log in `log/`, stamped with UTC time, ensuring chronological reconstruction of interactions.
+The assistant is invoked after login and serves as the primary shell for Arianna Core. Each session creates a fresh log in `/arianna_core/log/`, stamped with UTC time, ensuring chronological reconstruction of interactions.
 
 A `/status` command reports CPU core count, raw uptime seconds read from `/proc/uptime`, and the current host IP. This offers an at-a-glance check that the minimal environment is healthy.
 

--- a/assistant.py
+++ b/assistant.py
@@ -5,20 +5,29 @@ from __future__ import annotations
 
 import os
 import socket
+import sys
 from datetime import datetime
 from pathlib import Path
 from collections import deque
 from typing import Deque, Iterable
 
-# //: each session logs to its own file in the repository root
-ROOT_DIR = Path(__file__).resolve().parent
-LOG_DIR = ROOT_DIR / "log"
+# //: each session logs to its own file under a fixed directory
+LOG_DIR = Path("/arianna_core/log")
 SESSION_ID = datetime.utcnow().strftime("%Y%m%d-%H%M%S")
 LOG_PATH = LOG_DIR / f"{SESSION_ID}.log"
 
 
+def _ensure_log_dir() -> None:
+    """Verify that the log directory exists and is writable."""
+    if not LOG_DIR.exists():
+        print(f"Log directory {LOG_DIR} does not exist", file=sys.stderr)
+        raise SystemExit(1)
+    if not os.access(LOG_DIR, os.W_OK):
+        print(f"No write permission for {LOG_DIR}", file=sys.stderr)
+        raise SystemExit(1)
+
+
 def log(message: str) -> None:
-    LOG_DIR.mkdir(parents=True, exist_ok=True)
     with LOG_PATH.open("a") as fh:
         fh.write(f"{datetime.utcnow().isoformat()} {message}\n")
 
@@ -67,6 +76,7 @@ def summarize(term: str | None = None, limit: int = 5) -> str:
 
 
 def main() -> None:
+    _ensure_log_dir()
     log("session_start")
     print("Arianna assistant ready. Type 'exit' to quit.")
     while True:

--- a/build/build_ariannacore.sh
+++ b/build/build_ariannacore.sh
@@ -8,6 +8,7 @@ ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 KERNEL_VERSION="${KERNEL_VERSION:-6.6.4}"
 ACROOT_VERSION="${ACROOT_VERSION:-3.19.0}"
 CURL="curl --retry 3 --retry-delay 5 -fL"
+LOG_DIR="/arianna_core/log"
 
 WITH_PY=0
 CLEAN=0
@@ -80,7 +81,7 @@ apk --root acroot --repositories-file /etc/apk/repositories add --no-cache $PKGS
 install -Dm755 "$ROOT_DIR/assistant.py" acroot/usr/bin/assistant
 install -Dm755 "$ROOT_DIR/cmd/startup.py" acroot/usr/bin/startup
 ln -sf /usr/bin/startup acroot/init
-mkdir -p acroot/arianna_core/log
+mkdir -p "acroot${LOG_DIR}"
 echo "Hey there, welcome to Arianna Method Linux Terminal" > acroot/etc/motd
 
 # //: create initramfs image

--- a/cmd/monitor.sh
+++ b/cmd/monitor.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
-# Tail assistant logs from the repository root's log directory
+# Tail assistant logs from the system log directory
 
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-LOG_DIR="$ROOT_DIR/log"
+LOG_DIR="/arianna_core/log"
 
-mkdir -p "$LOG_DIR"
+if [ ! -d "$LOG_DIR" ]; then
+  echo "Log directory $LOG_DIR not found" >&2
+  exit 1
+fi
 # Wait for at least one log file to exist before tailing
 shopt -s nullglob
 log_files=("$LOG_DIR"/*.log)


### PR DESCRIPTION
## Summary
- hard-code assistant logs to `/arianna_core/log` and verify directory is writable
- update build and monitor scripts to use the new log location
- document the new log path

## Testing
- `shellcheck cmd/monitor.sh build/build_ariannacore.sh`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68932e8222108329b59ca9f05aad3f46