### PR TITLE
Use local security db for apk installs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ arianna_core/alpine-minirootfs-*
 arianna_core/rootfs/
 arianna_core/arianna.initramfs.gz
 arianna_core/arianna-core.img
+build/AM-alpine-security-database/


### PR DESCRIPTION
## Summary
- stage AM-alpine-security-database in build output
- include security database during apk package installs
- keep cloned security database out of version control

## Testing
- `shellcheck build/build_ariannacore.sh`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68932e19b45883298290e998c4d6e0c5