### PR TITLE
Trim optional setup scripts from alpine-conf build

### DIFF
--- a/for-codex-alpine-conf/Makefile
+++ b/for-codex-alpine-conf/Makefile
@@ -1,43 +1,49 @@
-VERSION		:= 3.20.0
+VERSION         := 3.20.0
 
-sysconfdir	?= /etc/lbu
+sysconfdir      ?= /etc/lbu
 
-PREFIX		?=
+PREFIX          ?=
 
-LIB_FILES	:= libalpine.sh dasd-functions.sh
-SBIN_FILES	:= copy-modloop\
-		lbu\
-		setup-acf\
-		setup-alpine\
-		setup-apkcache\
-		setup-apkrepos\
-		setup-bootable\
-		setup-desktop\
-		setup-devd\
-		setup-disk\
-		setup-dns\
-		setup-hostname\
-		setup-interfaces\
-		setup-keymap\
-		setup-lbu\
-		setup-mta\
-		setup-ntp\
-		setup-proxy\
-		setup-sshd\
-		setup-timezone\
-		setup-user\
-		setup-wayland-base\
-		setup-xen-dom0\
-		setup-xorg-base\
-		update-conf\
-		update-kernel
+LIB_FILES       := libalpine.sh dasd-functions.sh
 
-BIN_FILES	:= uniso
+# Core scripts required for a minimal boot environment.
+CORE_SBIN_FILES := copy-modloop\
+                lbu\
+                setup-alpine\
+                setup-apkcache\
+                setup-apkrepos\
+                setup-bootable\
+                setup-disk\
+                setup-hostname\
+                setup-interfaces\
+                setup-keymap\
+                setup-lbu\
+                setup-timezone\
+                setup-user\
+                update-conf\
+                update-kernel
 
-SCRIPTS		:= $(LIB_FILES) $(SBIN_FILES)
+# Additional utilities not required for minimal boot. Maintainers may
+# reintroduce them by appending OPTIONAL_SBIN_FILES to SBIN_FILES.
+OPTIONAL_SBIN_FILES := setup-acf\
+                setup-desktop\
+                setup-devd\
+                setup-dns\
+                setup-mta\
+                setup-ntp\
+                setup-proxy\
+                setup-sshd\
+                setup-wayland-base\
+                setup-xen-dom0\
+                setup-xorg-base
 
-ETC_LBU_FILES	:= lbu.conf
+SBIN_FILES      := $(CORE_SBIN_FILES)
 
+BIN_FILES       := uniso
+
+SCRIPTS         := $(LIB_FILES) $(SBIN_FILES)
+
+ETC_LBU_FILES   := lbu.conf
 GIT_REV		:= $(shell test -d .git && git describe || echo exported)
 ifneq ($(GIT_REV), exported)
 FULL_VERSION	:= $(patsubst $(PACKAGE)-%,%,$(GIT_REV))

--- a/for-codex-alpine-conf/README.md
+++ b/for-codex-alpine-conf/README.md
@@ -21,3 +21,24 @@ The main script is called `setup-alpine`, and it will perform basic system setup
   * etc.
 
 For further information, please see <https://pkgs.alpinelinux.org/package/edge/main/x86_64/alpine-conf> or the Alpine Linux documentation wiki at <https://wiki.alpinelinux.org>.
+
+## Minimal build exclusions
+
+The default build omits several optional setup utilities that are not
+required for a minimal bootable system:
+
+- `setup-acf` – ACF web interface
+- `setup-desktop` – desktop environment helpers
+- `setup-devd` – device management with devd
+- `setup-dns` – DNS resolver configuration
+- `setup-mta` – mail transfer agent setup
+- `setup-ntp` – network time synchronisation
+- `setup-proxy` – proxy configuration
+- `setup-sshd` – SSH server
+- `setup-wayland-base` – Wayland graphics stack
+- `setup-xen-dom0` – Xen Dom0 support
+- `setup-xorg-base` – Xorg graphics stack
+
+These scripts remain in the source tree but are excluded from the build by
+default.  Maintainers can reintroduce them by appending
+`OPTIONAL_SBIN_FILES` to `SBIN_FILES` in the `Makefile`.


### PR DESCRIPTION
## Summary
- split alpine-conf scripts into core vs optional to keep minimal build lean
- document omitted setup scripts and how to re-enable them

## Testing
- `./run-tests.sh` *(fails: prompted for GitHub credentials)*

------
https://chatgpt.com/codex/tasks/task_e_689339ff2bf88329b0397d00d9e41e82