### PR TITLE
Use local apk-tools source

### DIFF
--- a/build/build_apk_tools.sh
+++ b/build/build_apk_tools.sh
@@ -2,10 +2,11 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-APK_TOOLS_DIR="$SCRIPT_DIR/apk-tools"
+APK_TOOLS_DIR="$SCRIPT_DIR/../for-codex-alpine-apk-tools"
 
 if [ ! -d "$APK_TOOLS_DIR" ]; then
-  git clone https://github.com/AriannaMethod/AM-alpine-apk-tools "$APK_TOOLS_DIR"
+  echo "APK tools directory not found: $APK_TOOLS_DIR" >&2
+  exit 1
 fi
 
 make -C "$APK_TOOLS_DIR"

--- a/tests/test_apk_tools.py
+++ b/tests/test_apk_tools.py
@@ -1,8 +1,11 @@
 import subprocess
 from pathlib import Path
 
+
 def test_build_custom_apk():
-    script = Path(__file__).resolve().parents[1] / "build" / "build_apk_tools.sh"
-    apk_path = subprocess.check_output([str(script)]).decode().strip()
-    assert Path(apk_path).is_file()
-    subprocess.check_call([apk_path, "--version"])
+    repo_root = Path(__file__).resolve().parents[1]
+    script = repo_root / "build" / "build_apk_tools.sh"
+    subprocess.check_call([str(script)])
+    apk_path = repo_root / "for-codex-alpine-apk-tools" / "src" / "apk"
+    assert apk_path.is_file()
+    subprocess.check_call([str(apk_path), "--version"])


### PR DESCRIPTION
## Summary
- build apk-tools from the repository's `for-codex-alpine-apk-tools` directory instead of cloning
- adjust test to invoke the script and verify the binary from the local path

## Testing
- `flake8`
- `./run-tests.sh` *(fails: `EVP_MD_CTX` incomplete type while building apk-tools)*

------
https://chatgpt.com/codex/tasks/task_e_68933a5d37288329ad456f1f91d78ec9