### PR TITLE
Run CI in CPU-only environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,15 +7,17 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    env:
+      CUDA_VISIBLE_DEVICES: ''  # explicitly disable GPU access
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential curl bc bison flex libelf-dev libssl-dev qemu-system-x86 apk-tools
-      - name: Build kernel and initramfs
+      - name: Build kernel, initramfs and boot test (CPU-only)
         run: |
-          ./build/build_ariannacore.sh --clean
+          ./build/build_ariannacore.sh --clean --test-qemu
       - name: Run tests
         run: |
           python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 
 🔹 This is not just a Linux kernel. Arianna Core is a compact AI-first kernel framework.
 
+## Continuous Integration
+
+The CI pipeline builds the kernel and boots it in QEMU using only CPU resources. GPU devices and drivers are absent, and QEMU
+is invoked with software acceleration so the workflow succeeds on generic CPU-only runners.
+
 ## Building
 
 The project ships a single entry script, `./build/build_ariannacore.sh`, which acquires kernel sources, prepares an `arianna_core_root` userland and emits a flat image. Run it from a fresh checkout to obtain a `bzImage` coupled with an `initramfs` that is aware of the assistant and the motd.

--- a/build/build_ariannacore.sh
+++ b/build/build_ariannacore.sh
@@ -101,6 +101,8 @@ if [ "$TEST_QEMU" -eq 1 ]; then
     -nographic \
     -no-reboot \
     -serial mon:stdio \
+    -machine accel=tcg \
+    -vga none \
     -m 512M
 fi
 

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -1,0 +1,5 @@
+# Continuous Integration
+
+The CI workflow is designed to run entirely on CPU-only infrastructure. The build job installs no GPU drivers and passes
+`-machine accel=tcg -vga none` to QEMU, forcing software emulation. This ensures that the kernel image can be built and
+booted on generic runners without access to GPU hardware.


### PR DESCRIPTION
## Summary
- force QEMU to use software CPU emulation and disable graphics
- disable GPU devices in CI and boot test the build
- document CPU-only CI requirement

## Testing
- `pytest -q` *(fails: Username for 'https://github.com':)*

------
https://chatgpt.com/codex/tasks/task_e_689339dc21f48329ab437ec5c49c6727