### PR TITLE
docs: document vendored Alpine utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,22 @@ The current release embeds the following official values:
 
 If a checksum mismatch occurs the build aborts immediately.
 
+## Vendored Alpine utilities
+
+Two directories track minimal forks of Alpine Linux components:
+
+- `for-codex-alpine-apk-tools/` carries a pared-down copy of `apk-tools`.
+  `build/build_apk_tools.sh` compiles this tree and `build/build_ariannacore.sh`
+  stages the resulting `apk` binary into `arianna_core_root` to install
+  packages without network access.
+- `for-codex-alpine-conf/` contains the `alpine-conf` setup scripts with
+  optional helpers removed.  Run `make -C for-codex-alpine-conf` before the
+  main build if these utilities should be included in the initramfs.
+
+Keeping these components local aligns with the CPU-only, minimalistic design:
+the build remains self-contained, avoids heavy dependencies and produces a
+small userland that boots on generic hardware.
+
 ## Running in QEMU
 
 A minimal invocation uses the `arianna-core.img` created during the build. QEMU can operate in headless mode:


### PR DESCRIPTION
## Summary
- describe `for-codex-alpine-apk-tools/` and `for-codex-alpine-conf/`
- explain how build scripts use these directories to populate the rootfs
- note CPU-only, minimalistic design goals

## Testing
- no tests run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68933cf208cc8329a42726413dab9c34