### PR TITLE
Build apk-tools statically during rootfs assembly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ log/*.log
 build/kernel/
 build/acroot/
 build/arianna_core_root-*.tar.gz
+build/apk-tools/
+for-codex-alpine-apk-tools/out/

--- a/build/build_apk_tools.sh
+++ b/build/build_apk_tools.sh
@@ -2,14 +2,21 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-APK_TOOLS_DIR="$SCRIPT_DIR/../for-codex-alpine-apk-tools"
+APK_TOOLS_DIR="${APK_TOOLS_DIR:-$SCRIPT_DIR/../for-codex-alpine-apk-tools}"
+OUTPUT_DIR="${OUTPUT_DIR:-$APK_TOOLS_DIR/out}"
 
 if [ ! -d "$APK_TOOLS_DIR" ]; then
   echo "APK tools directory not found: $APK_TOOLS_DIR" >&2
   exit 1
 fi
 
-make -C "$APK_TOOLS_DIR"
+make -C "$APK_TOOLS_DIR" clean
+make -C "$APK_TOOLS_DIR" static
+make -C "$APK_TOOLS_DIR" DESTDIR="$OUTPUT_DIR" SBINDIR=/usr/bin install
+
+BIN="$OUTPUT_DIR/usr/bin/apk"
+strip --strip-unneeded "$BIN" 2>/dev/null || true
+rm -rf "${OUTPUT_DIR:?}/usr/share"
 
 # Print path to built apk binary
-echo "$APK_TOOLS_DIR/src/apk"
+echo "$BIN"

--- a/build/build_ariannacore.sh
+++ b/build/build_ariannacore.sh
@@ -79,7 +79,11 @@ for s in "${CORE_SCRIPTS[@]}"; do
 done
 
 # //: build and stage patched apk-tools
-APK_BIN="$("$SCRIPT_DIR/build_apk_tools.sh")"
+APK_SRC="$ROOT_DIR/for-codex-alpine-apk-tools"
+APK_BUILD="$SCRIPT_DIR/apk-tools"
+rm -rf "$APK_BUILD"
+cp -r "$APK_SRC" "$APK_BUILD"
+APK_BIN="$(APK_TOOLS_DIR="$APK_BUILD" "$SCRIPT_DIR/build_apk_tools.sh")"
 install -Dm755 "$APK_BIN" acroot/usr/bin/apk
 
 # //: install runtime packages using the patched apk
@@ -89,6 +93,8 @@ if [ "$WITH_PY" -eq 1 ]; then
 fi
 # shellcheck disable=SC2086
 "$APK_BIN" --root acroot --repositories-file /etc/apk/repositories add --no-cache $PKGS
+# Strip docs to keep footprint small
+rm -rf acroot/usr/share/man acroot/usr/share/doc
 
 # //: include assistant, startup hook, motd and log dir
 install -Dm755 "$ROOT_DIR/assistant.py" acroot/usr/bin/assistant


### PR DESCRIPTION
## Summary
- stage apk-tools sources into the build directory and install the static apk binary into the rootfs
- strip unneeded symbols and purge documentation to shrink the image footprint
- ignore apk-tools build output in git

## Testing
- `shellcheck build/build_apk_tools.sh build/build_ariannacore.sh` (passed, no output)
- `./run-tests.sh` *(fails: src/apk_package.h:51:20: error: field ‘mdctx’ has incomplete type)*


------
https://chatgpt.com/codex/tasks/task_e_68933d061ca48329a48abab8d831b0b1