### PR TITLE
Streamline kernel config for CPU-only use

### DIFF
--- a/build/arianna_kernel.config
+++ b/build/arianna_kernel.config
@@ -10,3 +10,17 @@ CONFIG_DEVTMPFS_MOUNT=y                    # //: auto-mount devtmpfs at boot
 CONFIG_TMPFS=y                             # //: temporary in-memory fs
 CONFIG_TMPFS_POSIX_ACL=y                   # //: ACL semantics on tmpfs
 CONFIG_UNIX=y                              # //: UNIX domain socket support
+CONFIG_NET=y                               # //: fundamental networking stack
+CONFIG_INET=y                              # //: IPv4 support
+CONFIG_NETDEVICES=y                        # //: network device framework
+CONFIG_ETHERNET=y                          # //: Ethernet controllers
+CONFIG_E1000=y                             # //: Intel PRO/1000 NIC
+CONFIG_VIRTIO_NET=y                        # //: virtio network device
+CONFIG_PCI=y                               # //: peripheral component interconnect bus
+CONFIG_BLK_DEV_SD=y                        # //: SCSI disk support
+CONFIG_ATA=y                               # //: ATA controller support
+CONFIG_SATA_AHCI=y                         # //: AHCI SATA disks
+CONFIG_VIRTIO_BLK=y                        # //: virtio block device
+CONFIG_VIRTIO_PCI=y                        # //: virtio over PCI
+# CONFIG_DRM is not set                     # //: disable GPU DRM subsystem
+# CONFIG_FB is not set                      # //: disable framebuffer drivers


### PR DESCRIPTION
## Summary
- Disable GPU and framebuffer subsystems
- Enable core networking and storage drivers for commodity hardware

## Testing
- `./run-tests.sh` (fails: `tests/test_apk_tools.py::test_build_custom_apk`)
- `build/build_ariannacore.sh --test-qemu` (fails: `gzip: stdin: unexpected end of file`)


------
https://chatgpt.com/codex/tasks/task_e_68933d4636cc8329b33b3a5740658574