### PR TITLE
Consolidate letsgo entrypoint path

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Node.js 18+ complements Python, providing asynchronous I/O modeled as a non-bloc
 
 Bash, curl, and nano compose the minimal interactive toolkit; each utility occupies a vertex in a dependency graph ensuring accessibility without bloat.
 
-The CLI terminal shipped in cmd/letsgo.py demonstrates logging and echo capabilities, acting as a proof of concept for higher-order reasoning modules.
+The CLI terminal shipped in `letsgo.py` demonstrates logging and echo capabilities, acting as a proof of concept for higher-order reasoning modules.
 
 Logs are stored in /arianna_core/log and each entry is timestamped, forming a sequence ((t_i, m_i)) representing chronological states of dialogue.
 

--- a/cmd/letsgo.py
+++ b/cmd/letsgo.py
@@ -1,1 +1,0 @@
-../letsgo.py

--- a/cmd/startup.py
+++ b/cmd/startup.py
@@ -3,7 +3,7 @@
 import subprocess
 from pathlib import Path
 
-LETSGO = Path(__file__).resolve().parent / "letsgo.py"
+LETSGO = Path(__file__).resolve().parent.parent / "letsgo.py"
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- remove duplicate `cmd/letsgo.py` so root `letsgo.py` is the canonical terminal
- update `cmd/startup.py` to run the root-level script
- fix documentation to reference the canonical `letsgo.py`

## Testing
- `flake8 cmd/startup.py`
- `./run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_689352f58b048329b20bd4c96fd366b9